### PR TITLE
bump prysmaticlabs/prysm to v1.0.0-beta.0, and sigp/lighthouse to v0.3.2

### DIFF
--- a/.github/workflows/auto_check.yml
+++ b/.github/workflows/auto_check.yml
@@ -1,9 +1,11 @@
 name: Bump upstream version
 
 on:
-  push:
   schedule:
     - cron: "00 */4 * * *"
+  push:
+    branches:
+      - "master"
 jobs:
   bump-upstream:
     runs-on: ubuntu-latest

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -42,12 +42,12 @@ RUN node getGitData /app/.git-data.json
 FROM debian:buster-slim as validator-binary
 
 ARG TARGETARCH
-ARG UPSTREAM_VERSION
+ARG UPSTREAM_VERSION_PRYSM
 ENV DOWNLOAD_URL https://github.com/prysmaticlabs/prysm/releases/download
 
 RUN DEBIAN_FRONTEND=noninteractive \
   apt update && apt install --assume-yes --no-install-recommends wget ca-certificates
-RUN wget -q $DOWNLOAD_URL/$UPSTREAM_VERSION/validator-$UPSTREAM_VERSION-linux-${TARGETARCH:-amd64} -O /usr/local/bin/validator && \
+RUN wget -q $DOWNLOAD_URL/$UPSTREAM_VERSION_PRYSM/validator-$UPSTREAM_VERSION_PRYSM-linux-${TARGETARCH:-amd64} -O /usr/local/bin/validator && \
   chmod +x  /usr/local/bin/validator && \
   rm -rf /var/lib/apt/lists/*
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -46,8 +46,8 @@ ARG UPSTREAM_VERSION
 ENV DOWNLOAD_URL https://github.com/prysmaticlabs/prysm/releases/download
 
 RUN DEBIAN_FRONTEND=noninteractive \
-  apt update && apt install --assume-yes --no-install-recommends wget ca-certificates && \
-  wget -q $DOWNLOAD_URL/$UPSTREAM_VERSION/validator-$UPSTREAM_VERSION-linux-${TARGETARCH:-amd64} -O /usr/local/bin/validator && \
+  apt update && apt install --assume-yes --no-install-recommends wget ca-certificates
+RUN wget -q $DOWNLOAD_URL/$UPSTREAM_VERSION/validator-$UPSTREAM_VERSION-linux-${TARGETARCH:-amd64} -O /usr/local/bin/validator && \
   chmod +x  /usr/local/bin/validator && \
   rm -rf /var/lib/apt/lists/*
 
@@ -59,14 +59,13 @@ FROM debian:buster-slim as lighthouse-binary
 ARG UPSTREAM_VERSION_LIGHTHOUSE
 ENV DOWNLOAD_URL https://github.com/sigp/lighthouse/releases/download
 
+RUN DEBIAN_FRONTEND=noninteractive \
+  apt update && apt install --assume-yes --no-install-recommends wget ca-certificates
 RUN export ARCH=$(uname -m) && \
-  export BINARY=lighthouse-${UPSTREAM_VERSION_LIGHTHOUSE}-${ARCH}-unknown-linux-gnu-portable.tar.gz && \
-  export BINARY_URL=${DOWNLOAD_URL}/${UPSTREAM_VERSION_LIGHTHOUSE}/${BINARY} && \
-  DEBIAN_FRONTEND=noninteractive \
-  apt update && apt install --assume-yes --no-install-recommends wget ca-certificates && \
-  wget -q $BINARY_URL && \
-  tar -xzvf $BINARY && \
-  rm -rf $BINARY && \
+  export BINARY_TARGZ=lighthouse-${UPSTREAM_VERSION_LIGHTHOUSE}-${ARCH}-unknown-linux-gnu-portable.tar.gz && \
+  wget -q ${DOWNLOAD_URL}/${UPSTREAM_VERSION_LIGHTHOUSE}/${BINARY_TARGZ} && \
+  tar -xzvf $BINARY_TARGZ && \
+  rm -rf $BINARY_TARGZ && \
   cp lighthouse /usr/local/bin/lighthouse && \
   chmod +x /usr/local/bin/lighthouse && \
   rm -rf /var/lib/apt/lists/*

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "medalla-validator.dnp.dappnode.eth",
   "version": "1.0.10",
-  "upstreamVersion": "v1.0.0-alpha.13",
+  "upstreamVersion": "prysmaticlabs/prysm@v1.0.0-beta.0, sigp/lighthouse@v0.3.2",
   "upstreamRepo": "prysmaticlabs/prysm,sigp/lighthouse",
   "upstreamArg": "UPSTREAM_VERSION_PRYSM,UPSTREAM_VERSION_LIGHTHOUSE",
   "shortDescription": "Eth2.0 Medalla testnet validator",
@@ -23,10 +23,7 @@
   "requirements": {
     "minimumDappnodeVersion": "0.2.37"
   },
-  "categories": [
-    "Blockchain",
-    "ETH2.0"
-  ],
+  "categories": ["Blockchain", "ETH2.0"],
   "links": {
     "homepage": "https://github.com/dappnode/DAppNodePackage-medalla-validator",
     "ui": "http://medalla-validator.dappnode/"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,25 @@
-version: '3.4'
+version: "3.4"
 services:
   medalla-validator.dnp.dappnode.eth:
-    image: 'medalla-validator.dnp.dappnode.eth:1.0.10'
+    image: "medalla-validator.dnp.dappnode.eth:1.0.10"
     build:
       context: .
       dockerfile: build/Dockerfile
       args:
-        UPSTREAM_VERSION_PRYSM: v1.0.0-beta.0-rc
-        UPSTREAM_VERSION_LIGHTHOUSE: v0.3.0
+        UPSTREAM_VERSION_PRYSM: v1.0.0-beta.0
+        UPSTREAM_VERSION_LIGHTHOUSE: v0.3.2
     volumes:
-      - 'keystores:/validators'
-      - 'lighthouse:/lighthouse'
-      - 'prysm:/prysm'
-      - 'logs:/var/log'
-      - 'db-api:/app/db-api'
+      - "keystores:/validators"
+      - "lighthouse:/lighthouse"
+      - "prysm:/prysm"
+      - "logs:/var/log"
+      - "db-api:/app/db-api"
     restart: always
     environment:
       - PASSWORD=
       - LOG_LEVEL=
       - GRAFFITI=validating_from_DAppNode
-      - 'WEB3PROVIDER=https://goerli.dappnode.net'
+      - "WEB3PROVIDER=https://goerli.dappnode.net"
       - LIGHTHOUSE_EXTRA_OPTS=
       - LIGHTHOUSE_VERBOSITY=
       - PRYSM_EXTRA_OPTS=


### PR DESCRIPTION
Bumps upstream version

- [prysmaticlabs/prysm](https://github.com/prysmaticlabs/prysm) from v1.0.0-beta.0-rc to [v1.0.0-beta.0](https://github.com/prysmaticlabs/prysm/releases/tag/v1.0.0-beta.0)
- [sigp/lighthouse](https://github.com/sigp/lighthouse) from v0.3.0 to [v0.3.2](https://github.com/sigp/lighthouse/releases/tag/v0.3.2)