### PR TITLE
bump prysmaticlabs/prysm to v1.0.0-beta.1

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "medalla-validator.dnp.dappnode.eth",
   "version": "1.0.10",
-  "upstreamVersion": "prysmaticlabs/prysm@v1.0.0-beta.0, sigp/lighthouse@v0.3.2",
+  "upstreamVersion": "v1.0.0-beta.1",
   "upstreamRepo": "prysmaticlabs/prysm,sigp/lighthouse",
   "upstreamArg": "UPSTREAM_VERSION_PRYSM,UPSTREAM_VERSION_LIGHTHOUSE",
   "shortDescription": "Eth2.0 Medalla testnet validator",
@@ -23,10 +23,7 @@
   "requirements": {
     "minimumDappnodeVersion": "0.2.37"
   },
-  "categories": [
-    "Blockchain",
-    "ETH2.0"
-  ],
+  "categories": ["Blockchain", "ETH2.0"],
   "links": {
     "homepage": "https://github.com/dappnode/DAppNodePackage-medalla-validator",
     "ui": "http://medalla-validator.dappnode/"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: build/Dockerfile
       args:
-        UPSTREAM_VERSION_PRYSM: v1.0.0-beta.0
+        UPSTREAM_VERSION_PRYSM: v1.0.0-beta.1
         UPSTREAM_VERSION_LIGHTHOUSE: v0.3.2
     volumes:
       - "keystores:/validators"


### PR DESCRIPTION
Bumps upstream version

- [prysmaticlabs/prysm](https://github.com/prysmaticlabs/prysm) from v1.0.0-beta.0 to [v1.0.0-beta.1](https://github.com/prysmaticlabs/prysm/releases/tag/v1.0.0-beta.1)