### PR TITLE
bump prysmaticlabs/prysm to v1.0.0-beta.2

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "medalla-validator.dnp.dappnode.eth",
   "version": "1.0.14",
-  "upstreamVersion": "prysmaticlabs/prysm@v1.0.0-beta.1, sigp/lighthouse@v0.3.3",
+  "upstreamVersion": "v1.0.0-beta.2",
   "upstreamRepo": "prysmaticlabs/prysm,sigp/lighthouse",
   "upstreamArg": "UPSTREAM_VERSION_PRYSM,UPSTREAM_VERSION_LIGHTHOUSE",
   "shortDescription": "Eth2.0 Medalla testnet validator",
@@ -22,10 +22,7 @@
   "requirements": {
     "minimumDappnodeVersion": "0.2.37"
   },
-  "categories": [
-    "Blockchain",
-    "ETH2.0"
-  ],
+  "categories": ["Blockchain", "ETH2.0"],
   "links": {
     "homepage": "https://github.com/dappnode/DAppNodePackage-medalla-validator",
     "ui": "http://medalla-validator.dappnode/"

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -7,6 +7,7 @@
   "shortDescription": "Eth2.0 Medalla testnet validator",
   "description": "A validator client which manages a staking user's private/public keys, connects to a beacon node, and acts as a validator in Ethereum 2.0 by staking 32 ETH and participating in proof of stake consensus by proposing and voting on blocks.",
   "type": "service",
+  "architectures": ["linux/amd64", "linux/arm64"],
   "author": "DAppNode Association <admin@dappnode.io> (https://github.com/dappnode)",
   "contributors": [
     "Eduardo Antuña <eduadiez@gmail.com> (https://github.com/eduadiez)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,25 @@
-version: '3.4'
+version: "3.4"
 services:
   medalla-validator.dnp.dappnode.eth:
-    image: 'medalla-validator.dnp.dappnode.eth:1.0.14'
+    image: "medalla-validator.dnp.dappnode.eth:1.0.14"
     build:
       context: .
       dockerfile: build/Dockerfile
       args:
-        UPSTREAM_VERSION_PRYSM: v1.0.0-beta.1
+        UPSTREAM_VERSION_PRYSM: v1.0.0-beta.2
         UPSTREAM_VERSION_LIGHTHOUSE: v0.3.3
     volumes:
-      - 'keystores:/validators'
-      - 'lighthouse:/lighthouse'
-      - 'prysm:/prysm'
-      - 'logs:/var/log'
-      - 'db-api:/app/db-api'
+      - "keystores:/validators"
+      - "lighthouse:/lighthouse"
+      - "prysm:/prysm"
+      - "logs:/var/log"
+      - "db-api:/app/db-api"
     restart: always
     environment:
       - PASSWORD=
       - LOG_LEVEL=
       - GRAFFITI=validating_from_DAppNode
-      - 'WEB3PROVIDER=https://goerli.dappnode.net'
+      - "WEB3PROVIDER=https://goerli.dappnode.net"
       - LIGHTHOUSE_EXTRA_OPTS=
       - LIGHTHOUSE_VERBOSITY=
       - PRYSM_EXTRA_OPTS=


### PR DESCRIPTION
Bumps upstream version

- [prysmaticlabs/prysm](https://github.com/prysmaticlabs/prysm) from v1.0.0-beta.1 to [v1.0.0-beta.2](https://github.com/prysmaticlabs/prysm/releases/tag/v1.0.0-beta.2)