### PR TITLE
bump prysmaticlabs/prysm to v1.0.0-beta.3, and sigp/lighthouse to v0.3.5

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "medalla-validator.dnp.dappnode.eth",
   "version": "1.0.15",
-  "upstreamVersion": "prysmaticlabs/prysm@v1.0.0-beta.2, sigp/lighthouse@v0.3.3",
+  "upstreamVersion": "prysmaticlabs/prysm@v1.0.0-beta.3, sigp/lighthouse@v0.3.5",
   "upstreamRepo": "prysmaticlabs/prysm,sigp/lighthouse",
   "upstreamArg": "UPSTREAM_VERSION_PRYSM,UPSTREAM_VERSION_LIGHTHOUSE",
   "shortDescription": "Eth2.0 Medalla testnet validator",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
       context: .
       dockerfile: build/Dockerfile
       args:
-        UPSTREAM_VERSION_PRYSM: v1.0.0-beta.2
-        UPSTREAM_VERSION_LIGHTHOUSE: v0.3.3
+        UPSTREAM_VERSION_PRYSM: v1.0.0-beta.3
+        UPSTREAM_VERSION_LIGHTHOUSE: v0.3.5
     volumes:
       - "keystores:/validators"
       - "lighthouse:/lighthouse"


### PR DESCRIPTION
Bumps upstream version

- [prysmaticlabs/prysm](https://github.com/prysmaticlabs/prysm) from v1.0.0-beta.2 to [v1.0.0-beta.3](https://github.com/prysmaticlabs/prysm/releases/tag/v1.0.0-beta.3)
- [sigp/lighthouse](https://github.com/sigp/lighthouse) from v0.3.3 to [v0.3.5](https://github.com/sigp/lighthouse/releases/tag/v0.3.5)